### PR TITLE
Split board seats into its own table to have a better control of their expiration

### DIFF
--- a/contracts/telos.board/src/telos.board.cpp
+++ b/contracts/telos.board/src/telos.board.cpp
@@ -143,7 +143,7 @@ void tfvt::startelect(name holder) {
 	uint32_t election_end_time = current_time_point().sec_since_epoch() + _config.leaderboard_duration;
 
     uint8_t min = 1;
-    uint8_t max = _config.open_seats;
+    uint8_t max = get_open_seats();
 
     action(permission_level{get_self(), name("active")}, TELOS_DECIDE_N, name("editminmax"), make_tuple(
             name(_config.open_election_id), // ballot name

--- a/contracts/telos.board/src/telos.board.cpp
+++ b/contracts/telos.board/src/telos.board.cpp
@@ -2,7 +2,9 @@
 #include <eosio/symbol.hpp>
 
 tfvt::tfvt(name self, name code, datastream<const char*> ds)
-: contract(self, code, ds), configs(get_self(), get_self().value) {
+: contract(self, code, ds),
+  configs(get_self(), get_self().value),
+  seats(get_self(), get_self().value) {
 	print("\n exists?: ", configs.exists());
 	_config = configs.exists() ? configs.get() : get_default_config();
 }
@@ -11,11 +13,9 @@ tfvt::~tfvt() {
 	if(configs.exists()) configs.set(_config, get_self());
 }
 
-tfvt::config tfvt::get_default_config() {
-	auto c = config {
+tfvt::configv2 tfvt::get_default_config() {
+	auto c = configv2 {
 		get_self(),			//publisher
-		uint8_t(12),		//max seats
-		uint8_t(12),        //open seats
 		name(),				//open_election_id
 		uint32_t(5), 		//holder_quorum_divisor
 		uint32_t(2), 		//board_quorum_divisor
@@ -23,7 +23,6 @@ tfvt::config tfvt::get_default_config() {
 		uint32_t(1200),  	//start_delay
 		uint32_t(2000000),  //leaderboard_duration
 		uint32_t(14515200),	//election_frequency
-		uint32_t(0),		//last_board_election_time
 		uint32_t(0),		//active election min time to start
 		false				//is_active_election
 	};
@@ -33,10 +32,9 @@ tfvt::config tfvt::get_default_config() {
 
 #pragma region Actions
 
-void tfvt::setconfig(name member, config new_config) { 
+void tfvt::setconfig(name member, configv2 new_config) {
     require_auth(get_self());
 	configs.remove();
-    check(new_config.max_board_seats >= new_config.open_seats, "can't have more open seats than max seats");
 	check(new_config.holder_quorum_divisor > 0, "holder_quorum_divisor must be a non-zero number");
 	check(new_config.board_quorum_divisor > 0, "board_quorum_divisor must be a non-zero number");
 	check(new_config.issue_duration > 0, "issue_duration must be a non-zero number");
@@ -44,18 +42,8 @@ void tfvt::setconfig(name member, config new_config) {
 	check(new_config.leaderboard_duration > 0, "leaderboard_duration must be a non-zero number");
 	check(new_config.election_frequency > 0, "election_frequency must be a non-zero number");
 
-	// NOTE : this will break an ongoing election check for makeelection 
-	if(new_config.max_board_seats >= _config.max_board_seats){
-		new_config.open_seats = new_config.max_board_seats - _config.max_board_seats + _config.open_seats;
-	}else if(new_config.max_board_seats > _config.max_board_seats - _config.open_seats){
-		new_config.open_seats = new_config.max_board_seats - (_config.max_board_seats - _config.open_seats);
-	}else{
-		new_config.open_seats = 0;
-	}
-
 	new_config.publisher = _config.publisher;
 	new_config.open_election_id = _config.open_election_id;
-	new_config.last_board_election_time = _config.last_board_election_time;
 	new_config.is_active_election = _config.is_active_election;
 
 	_config = new_config;
@@ -64,8 +52,7 @@ void tfvt::setconfig(name member, config new_config) {
 
 void tfvt::nominate(name nominee, name nominator) {
     require_auth(nominator);
-	check(is_account(nominee), "nominee account must exist");
-	check(!is_board_member(nominee) || is_term_expired(), "nominee is a board member, nominee's term must be expired");
+    check_nominee(nominee);
 
     nominees_table noms(get_self(), get_self().value);
     auto n = noms.find(nominee.value);
@@ -79,8 +66,8 @@ void tfvt::nominate(name nominee, name nominator) {
 void tfvt::makeelection(name holder, std::string description, std::string content) {
 	require_auth(holder);
 	check(!_config.is_active_election, "there is already an election in progress");
-	check(_config.open_seats > 0 || is_term_expired(), "it isn't time for the next election");
-	
+	check(get_open_seats() > 0, "It isn't time for the next election");
+
 	ballots_table ballots(TELOS_DECIDE_N, TELOS_DECIDE_N.value);
 
 	_config.open_election_id = get_next_ballot_id();
@@ -109,9 +96,14 @@ void tfvt::makeelection(name holder, std::string description, std::string conten
 		content
 	)).send();
 
-	if(is_term_expired()) {
-		_config.open_seats = _config.max_board_seats;
-	}
+    // Remove all the expired seats
+    for (auto itr = seats.begin(); itr != seats.end(); itr++) {
+        if (is_term_expired(itr->next_election_time))  {
+            seats.modify(itr, get_self(), [&](auto& s) {
+                s.member = name();
+            });
+        }
+    }
 
 	//NOTE: this prevents makeelection from being called multiple times.
 	//NOTE2 : this gets overwritten by setconfig
@@ -122,7 +114,10 @@ void tfvt::addcand(name candidate) {
 	require_auth(candidate);
 	check(is_nominee(candidate), "only nominees can be added to the election");
 	check(_config.is_active_election, "no active election for board members at this time");
-	check(!is_board_member(candidate) || is_term_expired(), "nominee can't already be a board member, or their term must be expired.");
+
+	auto seat = get_board_seat_by_user(candidate);
+
+	check(seat == seats.end() || is_term_expired(seat->next_election_time), "nominee can't already be a board member, or their term must be expired.");
 
     action(permission_level{get_self(), name("active")}, TELOS_DECIDE_N, name("addoption"), make_tuple(
 		_config.open_election_id, 	//ballot_id
@@ -176,12 +171,13 @@ void tfvt::endelect(name holder) {
 		sorted_candidates.push_back(make_pair(it->second.amount, it->first));
 	}
 	sort(sorted_candidates.begin(), sorted_candidates.end(), [](const auto &c1, const auto &c2) { return c1 > c2; });
-	
+
+    size_t open_seats = get_open_seats();
 	// Remove candidates tied with the [available-seats] - This discards all the tied on the tail
-	if (sorted_candidates.size() > _config.open_seats) {
-		auto first_cand_out = sorted_candidates[_config.open_seats];
-		sorted_candidates.resize(_config.open_seats);
-		
+	if (sorted_candidates.size() > open_seats) {
+		auto first_cand_out = sorted_candidates[open_seats];
+		sorted_candidates.resize(open_seats);
+
 		// count candidates that are tied with first_cand_out
 		uint8_t tied_cands = 0;
 		for(int i = sorted_candidates.size() - 1; i >= 0; i--) {
@@ -196,25 +192,16 @@ void tfvt::endelect(name holder) {
 		}
 	}
 
-	if(sorted_candidates.size() > 0 && is_term_expired()) {
-		remove_and_seize_all();
-		_config.last_board_election_time = current_time_point().sec_since_epoch();
-	}
-
     for (int n = 0; n < sorted_candidates.size(); n++) {
 		if(sorted_candidates[n].first > 0) {
 			add_to_tfboard(sorted_candidates[n].second);
 		}
     }
-    
+
 	vector<permission_level_weight> currently_elected = perms_from_members(); //NOTE: needs testing
 
 	if(currently_elected.size() > 0)
 		set_permissions(currently_elected);
-	
-	members_table members(_self, _self.value);
-
-	_config.open_seats = _config.max_board_seats - uint8_t(std::distance(members.begin(), members.end()));
 
 	action(permission_level{get_self(), name("active")}, TELOS_DECIDE_N, name("closevoting"), make_tuple(
 		_config.open_election_id,
@@ -227,8 +214,7 @@ void tfvt::removemember(name member_to_remove) {
 	require_auth(get_self());
 
 	remove_and_seize(member_to_remove);
-	_config.open_seats++;
-	
+
 	auto perms = perms_from_members();
 	set_permissions(perms);
 }
@@ -237,10 +223,83 @@ void tfvt::resign(name member) {
 	require_auth(member);
 
 	remove_and_seize(member);
-	_config.open_seats++;
-	
+
 	auto perms = perms_from_members();
 	set_permissions(perms);
+}
+
+void tfvt::removeseat(uint32_t seat_id) {
+    require_auth(get_self());
+
+    auto seat = seats.find(seat_id);
+    check(seat != seats.end(), "Unknown seat");
+    check(is_empty_seat(seat), "Seat is not empty");
+    seats.erase(seat);
+}
+
+void tfvt::updseatterms(std::map<uint32_t, uint32_t> seat_terms) {
+    require_auth(get_self());
+
+    for (auto const& it : seat_terms) {
+        auto seat = seats.find(it.first);
+        check(seat != seats.end(), "Unknown seat");
+        seats.modify(seat, get_self(), [&](auto& s) {
+            s.next_election_time = it.second;
+        });
+    }
+}
+
+void tfvt::migratestart() {
+    require_auth(get_self());
+
+    members_table members(get_self(), get_self().value);
+    config_table_old configs_old(get_self(), get_self().value);
+
+    check(configs_old.exists(), "No config to migrate from");
+    config config_old = configs_old.get();
+
+    // Move config
+    _config.publisher = config_old.publisher;
+    _config.open_election_id = config_old.open_election_id;
+    _config.holder_quorum_divisor = config_old.holder_quorum_divisor;
+    _config.board_quorum_divisor = config_old.board_quorum_divisor;
+    _config.issue_duration = config_old.issue_duration;
+    _config.start_delay = config_old.start_delay;
+    _config.leaderboard_duration = config_old.leaderboard_duration;
+    _config.election_frequency = config_old.election_frequency;
+    _config.active_election_min_start_time = config_old.active_election_min_start_time;
+    _config.is_active_election = config_old.is_active_election;
+
+    // Clean sets
+    auto it = seats.begin();
+    while(it != seats.end()) {
+        it = seats.erase(it);
+    }
+
+    // Move members to a seat
+    for (auto const& it : members) {
+        seats.emplace(get_self(), [&](auto& s) {
+            s.id = seats.available_primary_key();
+            s.member = it.member;
+            s.next_election_time = config_old.last_board_election_time + config_old.election_frequency;
+        });
+    }
+}
+
+void tfvt::migrateclean() {
+    require_auth(get_self());
+
+    config_table_old configs_old(get_self(), get_self().value);
+
+    // Delete old config
+    configs_old.remove();
+
+    // Delete members
+    members_table members(get_self(), get_self().value);
+    auto it = members.begin();
+    while(it != members.end()) {
+        it = members.erase(it);
+    }
 }
 
 #pragma endregion Actions
@@ -252,43 +311,43 @@ void tfvt::add_to_tfboard(name nominee) {
     nominees_table noms(get_self(), get_self().value);
     auto n = noms.find(nominee.value);
     check(n != noms.end(), "nominee doesn't exist in table");
-
-    members_table mems(get_self(), get_self().value);
-    auto m = mems.find(nominee.value);
-    check(m == mems.end(), "nominee is already a board member"); //NOTE: change if error occurs in live environment
-
-    noms.erase(n); //NOTE remove from nominee table
-
-    mems.emplace(get_self(), [&](auto& m) { //NOTE: emplace in boardmembers table
-        m.member = nominee;
+    auto seat = get_next_empty_seat();
+    seats.modify(seat, get_self(), [&](auto& s) {
+        s.member = nominee;
+        if (is_term_expired(s.next_election_time)) {
+            s.next_election_time += _config.election_frequency;
+        }
     });
+
+    noms.erase(n);
 }
 
-void tfvt::rmv_from_tfboard(name member) {
-    members_table mems(get_self(), get_self().value);
-    auto m = mems.find(member.value);
-    check(m != mems.end(), "member is not on the board");
-
-    mems.erase(m);
-}
-
-void tfvt::addseats(name member, uint8_t num_seats) {
+void tfvt::addseats(uint8_t num_seats) {
     require_auth(get_self());
 
-    config_table configs(get_self(), get_self().value);
-    auto c = configs.get();
-
-	c.max_board_seats += num_seats;
-	c.open_seats += num_seats;
-
-    configs.set(c, get_self());
+    for (size_t i = 0; i < num_seats; ++i) {
+        seats.emplace(get_self(), [&](auto& s) {
+            s.id = seats.available_primary_key();
+            s.member = name();
+            s.next_election_time = current_time_point().sec_since_epoch();
+        });
+    }
 }
 
 bool tfvt::is_board_member(name user) {
-    members_table mems(get_self(), get_self().value);
-    auto m = mems.find(user.value);
-	
-    return m != mems.end();
+    auto seat = get_board_seat_by_user(user);
+
+    return seat != seats.end();
+}
+
+tfvt::seats_table::const_iterator tfvt::get_board_seat_by_user(name user) {
+    for (auto seat = seats.begin(); seat != seats.end(); seat++) {
+        if (seat->member == user) {
+            return seat;
+        }
+    }
+
+    return seats.end();
 }
 
 bool tfvt::is_nominee(name user) {
@@ -298,26 +357,18 @@ bool tfvt::is_nominee(name user) {
     return n != noms.end();
 }
 
-bool tfvt::is_term_expired() {
-	return current_time_point().sec_since_epoch() - _config.last_board_election_time > _config.election_frequency;
-}
-
-void tfvt::remove_and_seize_all() {
-	members_table members(get_self(), get_self().value);
-
-	auto itr = members.begin();
-	vector<name> to_seize;
-	while(itr != members.end()) {
-		to_seize.emplace_back(itr->member);
-		itr = members.erase(itr);
-	}
+bool tfvt::is_term_expired(uint32_t next_election_time) {
+    return current_time_point().sec_since_epoch() >= next_election_time;
 }
 
 void tfvt::remove_and_seize(name member) {
-	members_table members(get_self(), get_self().value);
-	auto m = members.get(member.value, "board member not found");
 
-	members.erase(m);
+	auto seat = get_board_seat_by_user(member);
+	check(seat != seats.end(), "board member not found");
+
+    seats.modify(seat, get_self(), [&](auto& s) {
+        s.member = name();
+    });
 }
 
 void tfvt::set_permissions(vector<permission_level_weight> perms) {
@@ -331,14 +382,14 @@ void tfvt::set_permissions(vector<permission_level_weight> perms) {
 			}, active_weight}
 	);
 	sort(perms.begin(), perms.end(), [](const auto &first, const auto &second) { return first.permission.actor.value < second.permission.actor.value; });
-	
+
 	action(permission_level{get_self(), "owner"_n }, "eosio"_n, "updateauth"_n,
 		std::make_tuple(
-			get_self(), 
-			name("active"), 
+			get_self(),
+			name("active"),
 			name("owner"),
 			authority {
-				active_weight, 
+				active_weight,
 				std::vector<key_weight>{},
 				perms,
 				std::vector<wait_weight>{}
@@ -347,17 +398,17 @@ void tfvt::set_permissions(vector<permission_level_weight> perms) {
 	).send();
 
 	auto tf_it = std::find_if(perms.begin(), perms.end(), [&self](const permission_level_weight &lvlw) {
-        return lvlw.permission.actor == self; 
+        return lvlw.permission.actor == self;
     });
 	perms.erase(tf_it);
 	uint16_t minor_weight = perms.size() < 4 ? 1 : (perms.size() / 4);
 	action(permission_level{get_self(), "owner"_n }, "eosio"_n, "updateauth"_n,
 		std::make_tuple(
-			get_self(), 
-			name("minor"), 
+			get_self(),
+			name("minor"),
 			name("owner"),
 			authority {
-				minor_weight, 
+				minor_weight,
 				std::vector<key_weight>{},
 				perms,
 				std::vector<wait_weight>{}
@@ -367,15 +418,16 @@ void tfvt::set_permissions(vector<permission_level_weight> perms) {
 }
 
 vector<tfvt::permission_level_weight> tfvt::perms_from_members() {
-	members_table members(get_self(), get_self().value);
-	auto itr = members.begin();
-	
+	auto itr = seats.begin();
+
 	vector<permission_level_weight> perms;
-	while(itr != members.end()) {
-			perms.emplace_back(permission_level_weight{ permission_level{
-				itr->member,
-				"active"_n
-			}, 1});
+	while(itr != seats.end()) {
+	    if (!is_empty_seat(itr)) { // Only members from non empty seats are taken into account
+	        perms.emplace_back(permission_level_weight{ permission_level{
+                itr->member,
+                "active"_n
+            }, 1});
+	    }
 		itr++;
 	}
 
@@ -401,6 +453,45 @@ name tfvt::get_next_ballot_id() {
 	check(false, "couldn't secure a ballot_id");
 	// silence the compiler
 	return name();
+}
+
+size_t tfvt::get_open_seats() {
+    // Gets open seats
+    // An open seat is one that:
+    //   - Has no member OR
+    //   - next_election_time is in the past
+    int open_seats = 0;
+
+    for (auto seat = seats.begin(); seat != seats.end(); seat++) {
+        if (is_empty_seat(seat)) {
+            open_seats++;
+        }
+    }
+
+    return open_seats;
+}
+
+void tfvt::check_nominee(name nominee) {
+    check(is_account(nominee), "nominee account must exist");
+    if (is_board_member(nominee)) {
+        auto seat = get_board_seat_by_user(nominee);
+        check(is_term_expired(seat->next_election_time), "nominee is a board member, nominee's term must be expired");
+    }
+}
+
+tfvt::seats_table::const_iterator tfvt::get_next_empty_seat() {
+    for (auto seat = seats.begin(); seat != seats.end(); seat++) {
+        if (is_empty_seat(seat)) {
+            return seat;
+        }
+    }
+
+    check(false, "No empty seat remaining - this is likely a bug");
+    return seats.end(); // silence warning
+}
+
+bool tfvt::is_empty_seat(seats_table::const_iterator& seat) {
+    return seat->member == name() || is_term_expired(seat->next_election_time);
 }
 
 #pragma endregion Helper_Functions


### PR DESCRIPTION
## Description

Split board seats into its own table to have a better control of their expiration

 - Each board duration is independent
 - Elections will consider expired terms and nameless seats
 - open seats are computed depending the seat
 
Todo:
 - [x] Remove seat (multisig)
 - [x] Update seat (multisig)
 - [x] Migrations from old seats to new seats
 - [x] Migrate old config to new config
 - [x] Self review
 - [x] Testings

## Checklist:
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
